### PR TITLE
refactor: 사용자 auth 로직을 선언적으로 수정

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "trailingComma": "all",
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "printWidth": 70,
+  "useTabs": false,
+  "arrowParens": "avoid",
+  "endOfLine": "auto"
+}

--- a/src/components/base/Header.jsx
+++ b/src/components/base/Header.jsx
@@ -1,18 +1,10 @@
 import React from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { AiOutlineSearch, AiOutlineHome, AiOutlineSend } from "react-icons/ai";
+import { useAuth } from "../../hooks/useAuth";
 
 const Header = () => {
-  const navigate = useNavigate();
-
-  const onLogout = () => {
-    localStorage.removeItem("user");
-    localStorage.removeItem("email");
-    localStorage.removeItem("password");
-
-    alert("로그아웃 되었습니다.");
-    navigate("/login");
-  };
+  const { logoutCallback } = useAuth();
 
   return (
     <header className="header">
@@ -41,7 +33,7 @@ const Header = () => {
                 <AiOutlineSend />
               </li>
               <li>
-                <button type="button" onClick={onLogout}>
+                <button type="button" onClick={logoutCallback}>
                   LOGOUT
                 </button>
               </li>

--- a/src/components/member/LoginForm.jsx
+++ b/src/components/member/LoginForm.jsx
@@ -1,14 +1,15 @@
-import React, { useState, useRef } from "react";
-import { useNavigate } from "react-router-dom";
+import React, { useState, useRef } from 'react';
+import { useAuth } from '../../hooks/useAuth';
 
 const LoginForm = () => {
-  const navigate = useNavigate();
+  const { loginCallback } = useAuth();
 
   const [inputs, setInputs] = useState({
-    user: "",
-    email: "",
-    password: "",
+    user: '',
+    email: '',
+    password: '',
   });
+
   const inputId = useRef();
   const inputEmail = useRef();
   const inputPw = useRef();
@@ -22,12 +23,12 @@ const LoginForm = () => {
   const { user, email, password } = inputs;
 
   //input change event
-  const onChangeHandler = (e) => {
+  const onChangeHandler = e => {
     const idCurrent = inputId.current.value;
     const emailCurrent = inputEmail.current.value;
     const pwCurrent = inputPw.current.value;
 
-    if (idCurrent !== "") {
+    if (idCurrent !== '') {
       setStatusId(true);
     } else {
       setStatusId(false);
@@ -49,7 +50,7 @@ const LoginForm = () => {
 
     //이메일 && 비밀번호 유효성 검사 - 버튼 disabled 여부
     if (
-      idCurrent !== "" &&
+      idCurrent !== '' &&
       validationEmail(emailCurrent) &&
       validationPassword(pwCurrent)
     ) {
@@ -66,28 +67,14 @@ const LoginForm = () => {
     });
   };
 
-  //form 전송
-  const onSubmitHandler = (e) => {
+  // TODO: login 처리 로직 분리
+  const onSubmitHandler = e => {
     e.preventDefault();
-
-    if (
-      localStorage.getItem("email") === email &&
-      localStorage.getItem("password") === password
-    ) {
-      alert("등록된 이메일, 패스워드와 일치합니다.");
-    } else {
-      //로컬스토리지에 저장
-      localStorage.setItem("user", user);
-      localStorage.setItem("email", email);
-      localStorage.setItem("password", password);
-      alert("로그인 되었습니다.");
-      navigate("/");
-    }
+    loginCallback(inputs);
   };
 
-  //이메일 유효성 검사 함수
   function validationEmail(v) {
-    if (v === "") {
+    if (v === '') {
       return false;
     }
     const emailRegex =
@@ -101,7 +88,7 @@ const LoginForm = () => {
 
   //비밀번호 유효성 검사 함수
   function validationPassword(v) {
-    if (v === "") {
+    if (v === '') {
       return false;
     }
     const pwRegex =
@@ -123,7 +110,7 @@ const LoginForm = () => {
         ref={inputId}
         onChange={onChangeHandler}
         placeholder="닉네임"
-        className={(statusId ? "" : "error") + " w100"}
+        className={(statusId ? '' : 'error') + ' w100'}
       />
       <input
         type="text"
@@ -131,7 +118,7 @@ const LoginForm = () => {
         ref={inputEmail}
         onChange={onChangeHandler}
         placeholder="이메일"
-        className={(statusEmail ? "" : "error") + " w100"}
+        className={(statusEmail ? '' : 'error') + ' w100'}
       />
       <input
         type="password"
@@ -139,12 +126,12 @@ const LoginForm = () => {
         ref={inputPw}
         onChange={onChangeHandler}
         placeholder="비밀번호"
-        className={(statusPw ? "" : "error") + " w100"}
+        className={(statusPw ? '' : 'error') + ' w100'}
       />
       <button
         type="submit"
         className="btn btn-point w100"
-        disabled={statusBtn ? "" : "disabled"}
+        disabled={statusBtn ? '' : 'disabled'}
       >
         로그인
       </button>

--- a/src/hooks/useAuth.jsx
+++ b/src/hooks/useAuth.jsx
@@ -1,0 +1,48 @@
+import { useNavigate } from 'react-router-dom';
+import { useUserDispatch } from '../store/auth/provider';
+import { checkIsVerifyAccount } from '../util/checkIsVerifyAccount';
+
+/**
+ * useAuth
+ * @typedef { function }
+ * @function login, logout 콜백함수를 모아두는 hook
+ * @return { function } login 콜백함수
+ * @return { function } logout 콜백함수
+ */
+export function useAuth() {
+  const navigate = useNavigate();
+  const dispatch = useUserDispatch();
+
+  const loginCallback = getLoginCallback(navigate, dispatch);
+  const logoutCallback = getLogoutCallback(navigate, dispatch);
+
+  return { loginCallback, logoutCallback };
+}
+
+const getLoginCallback =
+  (navigate, dispatch) => async inputValues => {
+    const { user, email, password } = inputValues;
+    const isUserExist = checkIsVerifyAccount({ email, password });
+
+    if (!isUserExist) {
+      alert('아이디 또는 비밀번호를 잘못 입력하셨습니다!');
+      return;
+    }
+
+    dispatch({
+      type: 'LOGIN',
+      user,
+    });
+
+    alert('로그인 성공하였습니다.');
+    navigate('/', { replace: true });
+  };
+
+const getLogoutCallback = (navigate, dispatch) => async () => {
+  alert('로그아웃 되었습니다.');
+  dispatch({
+    type: 'LOGOUT',
+  });
+
+  navigate('/login', { replace: true });
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,23 +1,26 @@
-import React from "react";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
-import ReactDOM from "react-dom/client";
-import GlobalStyles from "./styles/globalStyles";
-import "./styles/layout.scss";
+import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { UserProvider } from './store/auth/provider';
+import ReactDOM from 'react-dom/client';
+import GlobalStyles from './styles/globalStyles';
+import './styles/layout.scss';
 
-import App from "./App";
-import Login from "./pages/Login";
+import App from './App';
+import Login from './pages/Login';
 
-const root = ReactDOM.createRoot(document.getElementById("root"));
+const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <GlobalStyles />
-    <BrowserRouter basename={process.env.PUBLIC_URL}>
-      <Routes>
-        {/* 홈 */}
-        <Route path="/" element={<App />} />
-        {/* 로그인 */}
-        <Route path="/login" element={<Login />} />
-      </Routes>
-    </BrowserRouter>
-  </React.StrictMode>
+    <UserProvider>
+      <GlobalStyles />
+      <BrowserRouter basename={process.env.PUBLIC_URL}>
+        <Routes>
+          {/* 홈 */}
+          <Route path="/" element={<App />} />
+          {/* 로그인 */}
+          <Route path="/login" element={<Login />} />
+        </Routes>
+      </BrowserRouter>
+    </UserProvider>
+  </React.StrictMode>,
 );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,20 +1,16 @@
-import React, { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
-import Layout from "../components/base/Layout";
-import Feeds from "../components/feed/Feeds";
-import Axios from "axios";
+import React, { useState, useEffect } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useUserState } from '../store/auth/provider';
+import Layout from '../components/base/Layout';
+import Feeds from '../components/feed/Feeds';
+import Axios from 'axios';
 
 const Home = () => {
-  const navigate = useNavigate();
+  const { token } = useUserState();
   const [feeds, setFeeds] = useState();
   const path = `${process.env.PUBLIC_URL}/data/feedData.json`;
 
   useEffect(() => {
-    if (!localStorage.getItem("email")) {
-      alert("로그인 해주세요.");
-      navigate("/login");
-    }
-
     const fetchData = async () => {
       try {
         const result = await Axios(path);
@@ -27,12 +23,16 @@ const Home = () => {
     fetchData();
   }, []);
 
+  // TODO: Routes 폴더에서 라우팅 처리해주기
   return (
-    <Layout>
-      <div className="main">
-        <Feeds data={feeds} />
-      </div>
-    </Layout>
+    <>
+      {!token && <Navigate to="/login" replace={true} />}
+      <Layout>
+        <div className="main">
+          <Feeds data={feeds} />
+        </div>
+      </Layout>
+    </>
   );
 };
 

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,48 +1,62 @@
-import React from "react";
-import { Link } from "react-router-dom";
-import Layout from "../components/base/Layout";
-import LoginForm from "../components/member/LoginForm";
-import { FaFacebookSquare } from "react-icons/fa";
+import React from 'react';
+import { Link, Navigate } from 'react-router-dom';
+import { useUserState } from '../store/auth/provider';
+import Layout from '../components/base/Layout';
+import LoginForm from '../components/member/LoginForm';
+import { FaFacebookSquare } from 'react-icons/fa';
 
 const Login = () => {
+  const { token } = useUserState();
+
+  // TODO: Routes 폴더에서 라우팅 처리해주기
   return (
-    <Layout>
-      <div className="login">
-        <div className="login-content">
-          <div className="login-form">
-            <h2>
-              <img src={require("../assets/images/logo.png")} alt="" />
-            </h2>
-            <LoginForm />
-            <div className="login-hr">
-              <span></span>
-              <span>또는</span>
-              <span></span>
+    <>
+      {token && <Navigate to="/" replace={true} />}
+      <Layout>
+        <div className="login">
+          <div className="login-content">
+            <div className="login-form">
+              <h2>
+                <img
+                  src={require('../assets/images/logo.png')}
+                  alt=""
+                />
+              </h2>
+              <LoginForm />
+              <div className="login-hr">
+                <span></span>
+                <span>또는</span>
+                <span></span>
+              </div>
+              <div className="login-facebook">
+                <FaFacebookSquare />
+                <Link to="/">Facebook으로 로그인</Link>
+              </div>
+              <Link to="/">비밀번호를 잊으셨나요?</Link>
             </div>
-            <div className="login-facebook">
-              <FaFacebookSquare />
-              <Link to="/">Facebook으로 로그인</Link>
+            <div className="login-account">
+              <span>계정이 없으신가요?</span>
+              <Link to="/">가입하기</Link>
             </div>
-            <Link to="/">비밀번호를 잊으셨나요?</Link>
-          </div>
-          <div className="login-account">
-            <span>계정이 없으신가요?</span>
-            <Link to="/">가입하기</Link>
-          </div>
-          <div className="login-download">
-            <p>앱을 다운로드 하세요.</p>
-            <div className="apps">
-              <Link to="/">
-                <img src={require("../assets/images/download_ios.png")}></img>
-              </Link>
-              <Link to="/">
-                <img src={require("../assets/images/download_and.png")}></img>
-              </Link>
+            <div className="login-download">
+              <p>앱을 다운로드 하세요.</p>
+              <div className="apps">
+                <Link to="/">
+                  <img
+                    src={require('../assets/images/download_ios.png')}
+                  ></img>
+                </Link>
+                <Link to="/">
+                  <img
+                    src={require('../assets/images/download_and.png')}
+                  ></img>
+                </Link>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    </Layout>
+      </Layout>
+    </>
   );
 };
 

--- a/src/store/auth/provider.jsx
+++ b/src/store/auth/provider.jsx
@@ -1,0 +1,27 @@
+import React, { createContext, useContext, useReducer } from 'react';
+import { initialState, authReducer } from './reducer';
+
+const UserStateContext = createContext(null);
+const UserDispatchContext = createContext(null);
+
+export const UserProvider = ({ children }) => {
+  const [state, dispatch] = useReducer(authReducer, initialState);
+
+  return (
+    <UserStateContext.Provider value={state}>
+      <UserDispatchContext.Provider value={dispatch}>
+        {children}
+      </UserDispatchContext.Provider>
+    </UserStateContext.Provider>
+  );
+};
+
+export const useUserState = () => {
+  const state = useContext(UserStateContext);
+  return state;
+};
+
+export const useUserDispatch = () => {
+  const dispatch = useContext(UserDispatchContext);
+  return dispatch;
+};

--- a/src/store/auth/reducer.jsx
+++ b/src/store/auth/reducer.jsx
@@ -1,0 +1,29 @@
+const initialState = {
+  token: JSON.parse(localStorage.getItem('authToken')),
+  user: localStorage.getItem('user'),
+};
+
+const authReducer = (state, { type, user }) => {
+  switch (type) {
+    case 'LOGIN':
+      localStorage.setItem('authToken', true);
+      localStorage.setItem('user', user);
+      return {
+        ...state,
+        token: true,
+        user,
+      };
+    case 'LOGOUT':
+      localStorage.removeItem('authToken');
+      localStorage.removeItem('user');
+      return {
+        ...state,
+        token: false,
+        user,
+      };
+    default:
+      return state;
+  }
+};
+
+export { initialState, authReducer };

--- a/src/util/checkIsVerifyAccount.jsx
+++ b/src/util/checkIsVerifyAccount.jsx
@@ -1,0 +1,32 @@
+const DUMMY_USER = [
+  {
+    userEmail: 'test12@naver.com',
+    userPassword: 'Test12345!',
+  },
+  {
+    userEmail: 'test23@naver.com',
+    userPassword: 'Test12345!',
+  },
+  {
+    userEmail: 'test34@naver.com',
+    userPassword: 'Test12345!',
+  },
+];
+
+/**
+ * checkIsVerifyAccount
+ * @typedef { function }
+ * @function checkIsVerifyAccount - 입력받은 values에 해당하는 사용자가 존재하는지 판별
+ * @param { object } 입력된 email, password 객체
+ * @param { array } 가입된 유저 리스트 Dummy data
+ * @return { boolean } 일치하는 사용자가 존재하는지 여부
+ */
+export function checkIsVerifyAccount({ email, password }) {
+  const isUserExist = DUMMY_USER.find(
+    ({ userEmail, userPassword }) => {
+      return email === userEmail && password === userPassword;
+    },
+  );
+
+  return Boolean(isUserExist);
+}


### PR DESCRIPTION
# Refactor :  사용자 auth 로직을 선언적으로 수정

## 🤔 기존 코드 구현 방식 : 명령형 flow
기존의 로그인, 로그아웃 처리 로직의 경우 해당 로직이 사용되는  컴포넌트 내에서 정의해주었다. 즉 명령형으로 흐름이 진행되었다. 이 경우 각 컴포넌트가 view 이외에도 logic을 담당하게 되므로 역할이 커지게 된다. 

## ♻ 리펙토링 : hook을 이용한 선언적 flow
따라서 useAuth 훅을 따로 빼주어 login과 logout 처리 로직을 선언적으로 수정하였다.

플로우는 다음과 같다.
1. 버튼을 클릭했을 때 임의의 유효성 검사(login form)를 거치게 된다.
2. 로컬 스토리지와 context의 값을 수정한다.
3. 임의의 페이지로 이동하는 처리를 진행한다.

핵심은 로직이 수행되는 컴포넌트는 버튼을 클릭한 뒤의 로직을 모른다는 것이다.

close #1 