### PR TITLE
[#20] refactor: use the routes file to handle routing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,13 @@
 import React from 'react';
-import Home from './pages/Home';
+import { UserProvider } from './store/auth/provider';
+import Routes from './routes';
 
-// TODO: Route 파일을 만든 후 App에서 해당 라우트를 렌더링
 function App() {
-  return <Home />;
+  return (
+    <UserProvider>
+      <Routes />
+    </UserProvider>
+  );
 }
 
 export default App;

--- a/src/components/member/LoginForm.jsx
+++ b/src/components/member/LoginForm.jsx
@@ -67,7 +67,6 @@ const LoginForm = () => {
     });
   };
 
-  // TODO: login 처리 로직 분리
   const onSubmitHandler = e => {
     e.preventDefault();
     loginCallback(inputs);

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -1,0 +1,2 @@
+export const ROUTE_PATH__LOGIN = '/login';
+export const ROUTE_PATH__HOME = '/';

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,11 @@
 import React from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 import { UserProvider } from './store/auth/provider';
 import ReactDOM from 'react-dom/client';
 import GlobalStyles from './styles/globalStyles';
 import './styles/layout.scss';
 
 import App from './App';
-import Login from './pages/Login';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
@@ -14,12 +13,7 @@ root.render(
     <UserProvider>
       <GlobalStyles />
       <BrowserRouter basename={process.env.PUBLIC_URL}>
-        <Routes>
-          {/* 홈 */}
-          <Route path="/" element={<App />} />
-          {/* 로그인 */}
-          <Route path="/login" element={<Login />} />
-        </Routes>
+        <App />
       </BrowserRouter>
     </UserProvider>
   </React.StrictMode>,

--- a/src/layout/AuthBtn.jsx
+++ b/src/layout/AuthBtn.jsx
@@ -1,0 +1,25 @@
+import { useUserState } from '../store/auth/provider';
+import { useAuth } from '../hooks/useAuth';
+
+export default function AuthBtn() {
+  const { token } = useUserState();
+  const { logoutCallback } = useAuth();
+  return (
+    <>
+      {token && <LogoutBtn submitCallback={logoutCallback} />}
+      {token || <LoginBtn />}
+    </>
+  );
+}
+
+const LoginBtn = () => {
+  return <button type="button">LOGIN</button>;
+};
+
+const LogoutBtn = ({ submitCallback }) => {
+  return (
+    <button type="button" onClick={submitCallback}>
+      LOGOUT
+    </button>
+  );
+};

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { useUserState } from '../store/auth/provider';
 import {
   AiOutlineSearch,
   AiOutlineHome,
   AiOutlineSend,
 } from 'react-icons/ai';
-import { useAuth } from '../hooks/useAuth';
+import AuthBtn from './AuthBtn';
 
 const Header = () => {
-  const { logoutCallback } = useAuth();
-
+  const { user } = useUserState();
   return (
     <header className="header">
       <div className="inner">
@@ -32,6 +32,7 @@ const Header = () => {
           </div>
           <nav className="gnb">
             <ul>
+              <li>{user && <span>닉네임: {user}</span>}</li>
               <li>
                 <Link to="/">
                   <AiOutlineHome />
@@ -41,9 +42,7 @@ const Header = () => {
                 <AiOutlineSend />
               </li>
               <li>
-                <button type="button" onClick={logoutCallback}>
-                  LOGOUT
-                </button>
+                <AuthBtn />
               </li>
             </ul>
           </nav>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -6,7 +6,6 @@ import Feeds from '../components/feed/Feeds';
 import Axios from 'axios';
 
 const Home = () => {
-  const { token } = useUserState();
   const [feeds, setFeeds] = useState();
   const path = `${process.env.PUBLIC_URL}/data/feedData.json`;
 
@@ -23,16 +22,12 @@ const Home = () => {
     fetchData();
   }, []);
 
-  // TODO: Routes 폴더에서 라우팅 처리해주기
   return (
-    <>
-      {!token && <Navigate to="/login" replace={true} />}
-      <Layout>
-        <div className="main">
-          <Feeds data={feeds} />
-        </div>
-      </Layout>
-    </>
+    <Layout>
+      <div className="main">
+        <Feeds data={feeds} />
+      </div>
+    </Layout>
   );
 };
 

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -6,57 +6,51 @@ import LoginForm from '../components/member/LoginForm';
 import { FaFacebookSquare } from 'react-icons/fa';
 
 const Login = () => {
-  const { token } = useUserState();
-
-  // TODO: Routes 폴더에서 라우팅 처리해주기
   return (
-    <>
-      {token && <Navigate to="/" replace={true} />}
-      <Layout>
-        <div className="login">
-          <div className="login-content">
-            <div className="login-form">
-              <h2>
+    <Layout>
+      <div className="login">
+        <div className="login-content">
+          <div className="login-form">
+            <h2>
+              <img
+                src={require('../assets/images/logo.png')}
+                alt=""
+              />
+            </h2>
+            <LoginForm />
+            <div className="login-hr">
+              <span></span>
+              <span>또는</span>
+              <span></span>
+            </div>
+            <div className="login-facebook">
+              <FaFacebookSquare />
+              <Link to="/">Facebook으로 로그인</Link>
+            </div>
+            <Link to="/">비밀번호를 잊으셨나요?</Link>
+          </div>
+          <div className="login-account">
+            <span>계정이 없으신가요?</span>
+            <Link to="/">가입하기</Link>
+          </div>
+          <div className="login-download">
+            <p>앱을 다운로드 하세요.</p>
+            <div className="apps">
+              <Link to="/">
                 <img
-                  src={require('../assets/images/logo.png')}
-                  alt=""
-                />
-              </h2>
-              <LoginForm />
-              <div className="login-hr">
-                <span></span>
-                <span>또는</span>
-                <span></span>
-              </div>
-              <div className="login-facebook">
-                <FaFacebookSquare />
-                <Link to="/">Facebook으로 로그인</Link>
-              </div>
-              <Link to="/">비밀번호를 잊으셨나요?</Link>
-            </div>
-            <div className="login-account">
-              <span>계정이 없으신가요?</span>
-              <Link to="/">가입하기</Link>
-            </div>
-            <div className="login-download">
-              <p>앱을 다운로드 하세요.</p>
-              <div className="apps">
-                <Link to="/">
-                  <img
-                    src={require('../assets/images/download_ios.png')}
-                  ></img>
-                </Link>
-                <Link to="/">
-                  <img
-                    src={require('../assets/images/download_and.png')}
-                  ></img>
-                </Link>
-              </div>
+                  src={require('../assets/images/download_ios.png')}
+                ></img>
+              </Link>
+              <Link to="/">
+                <img
+                  src={require('../assets/images/download_and.png')}
+                ></img>
+              </Link>
             </div>
           </div>
         </div>
-      </Layout>
-    </>
+      </div>
+    </Layout>
   );
 };
 

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useRoutes, Navigate } from 'react-router-dom';
+import {
+  ROUTE_PATH__LOGIN,
+  ROUTE_PATH__HOME,
+} from '../constants/routes.js';
+import { useUserState } from '../store/auth/provider';
+import Home from '../pages/Home';
+import Login from '../pages/Login';
+
+const RequireAuthNavigation = ({ children, token }) =>
+  !token ? <Navigate to={ROUTE_PATH__LOGIN} replace /> : children;
+
+const AuthenticatedUserNavigation = ({ children, token }) =>
+  token ? <Navigate to={ROUTE_PATH__HOME} replace /> : children;
+
+const Routes = () => {
+  const { token } = useUserState();
+  const routes = useRoutes([
+    {
+      path: ROUTE_PATH__LOGIN,
+      element: (
+        <AuthenticatedUserNavigation token={token}>
+          <Login />
+        </AuthenticatedUserNavigation>
+      ),
+    },
+    {
+      path: ROUTE_PATH__HOME,
+      element: (
+        <RequireAuthNavigation token={token}>
+          <Home />
+        </RequireAuthNavigation>
+      ),
+    },
+  ]);
+
+  return routes;
+};
+
+export default Routes;


### PR DESCRIPTION
# Refactor: use the routes file to handle routing

## 🤔 기존 코드 구현 방식 : 각 페이지에서 처리되는 리다이렉트

기존 코드 방식은 각 페이지에서 토큰 여부에 따라 useNavigation 훅을 이용해 리다이렉션 하였다.

이 것보다 더 나은 방식이 무엇이 있을까 하던 중 사전 과제 해설에서는 routes 파일을 빼서 구현했음을 .

사전 과제의 경우 라우팅 및 리다이렉트를 처리하는 Routes 컴포넌트로 구현하였다.
useRoutes의 element에서 리다이렉트를 구현하는 방식이 상당히 인상 깊어, 이를 토대로 리펙토링을 진행하였다.


## ♻ 기능 수정 : 라우팅 및 리다이렉트를 구현하는 Routes 컴포넌트

- useRoutes 훅을 이용해 라우팅 처리
- 각 element에서 토큰 여부에 따라 리다이렉트 구현

close #20 